### PR TITLE
Fix isUnlockedDoor condition to check actions length

### DIFF
--- a/src/main/java/com/BarrowsDoorHighlighter/BarrowsDoorHighlighterOverlay.java
+++ b/src/main/java/com/BarrowsDoorHighlighter/BarrowsDoorHighlighterOverlay.java
@@ -70,7 +70,7 @@ class BarrowsDoorHighlighterOverlay extends Overlay
             if (impostor != null)
             {
                 final Shape polygon;
-                final boolean isUnlockedDoor = impostor.getActions()[0] != null;
+                final boolean isUnlockedDoor = impostor.getActions().length > 0;
                 final Color color = isUnlockedDoor ? config.unlockedDoorColor() : config.lockedDoorColor();
                 if ((config.highlightDoors() != BarrowsDoorHighlighterConfig.HighlightDoors.UNLOCKED && !isUnlockedDoor)
                         || (config.highlightDoors() != BarrowsDoorHighlighterConfig.HighlightDoors.LOCKED && isUnlockedDoor)) 


### PR DESCRIPTION
I changed the way that the plugin was checking for options on the doors. When checking if action[0]  was null, it was causing an index out of bounds error because the doors that are locked didn't have any action and thus the returned value of getActions was `[]`.

If the length of getActions() is checked instead, only the doors that are unlocked will be highlighted.

Screenshot below is with this fix in place.
<img width="1278" height="709" alt="image" src="https://github.com/user-attachments/assets/a3a3d69e-d054-41b3-a2f0-9b08a356e981" />
