### PR TITLE
Replace deprecated client.getPlane usage

### DIFF
--- a/src/main/java/com/BarrowsDoorHighlighter/BarrowsDoorHighlighterOverlay.java
+++ b/src/main/java/com/BarrowsDoorHighlighter/BarrowsDoorHighlighterOverlay.java
@@ -54,7 +54,7 @@ class BarrowsDoorHighlighterOverlay extends Overlay
     @Override
     public Dimension render(Graphics2D graphics)
     {
-        if (client.getPlane() == 0 && config.highlightDoors() != BarrowsDoorHighlighterConfig.HighlightDoors.NEITHER)
+        if (client.getTopLevelWorldView().getPlane() == 0 && config.highlightDoors() != BarrowsDoorHighlighterConfig.HighlightDoors.NEITHER)
         {
             renderDoors(graphics);
         }


### PR DESCRIPTION
## Summary
- replace deprecated client.getPlane() with client.getTopLevelWorldView().getPlane()

## Why
This removes the deprecated API usage.

## Note
This PR targets ix/run-task-and-latest-runelite because the replacement API is only available after the RuneLite dependency update.