### PR TITLE
Remove overlay on plugin shutdown

### DIFF
--- a/src/main/java/com/BarrowsDoorHighlighter/BarrowsDoorHighlighter.java
+++ b/src/main/java/com/BarrowsDoorHighlighter/BarrowsDoorHighlighter.java
@@ -106,6 +106,7 @@ public class BarrowsDoorHighlighter extends Plugin
     @Override
     protected void shutDown() throws Exception
     {
+        overlayManager.remove(barrowsDoorHighlighterOverlay);
         doors.clear();
     }
     @Subscribe


### PR DESCRIPTION
- remove the Barrows overlay from the overlay manager during plugin shutdown